### PR TITLE
chore: Use trusted publishers in build-release

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -39,13 +39,14 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Update NPM
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm install
 
       - name: Publish package
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   publish-github:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added a step to update NPM to the latest version before installing dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build and release process to use the latest NPM version during package publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->