### PR TITLE
Single-source versioning from package.json, drop github-tag-action

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -8,26 +8,41 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+    outputs:
+      new_version: ${{ steps.version.outputs.version }}
+      released: ${{ steps.version.outputs.released }}
     steps:
       - name: Repo checkout
         uses: actions/checkout@v4
-
-      - name: Bump version and push tag
-        id: bump
-        uses: mathieudutour/github-tag-action@v6.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          release_branches: main
+          fetch-depth: 0
 
-      - name: Release tag
+      - name: Resolve version from package.json
+        id: version
+        run: |
+          VERSION=$(jq -r .version package.json)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            echo "Tag v$VERSION already exists — skipping release."
+          else
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create release
+        if: steps.version.outputs.released == 'true'
         uses: ncipollo/release-action@v1
         with:
-          tag: ${{ steps.bump.outputs.new_tag }}
+          tag: v${{ steps.version.outputs.version }}
           generateReleaseNotes: true
 
   publish-npmjs:
     runs-on: ubuntu-latest
     needs: [release]
+    if: needs.release.outputs.released == 'true'
     permissions:
       contents: read
       id-token: write
@@ -51,6 +66,7 @@ jobs:
   publish-github:
     runs-on: ubuntu-latest
     needs: [release]
+    if: needs.release.outputs.released == 'true'
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Related Issue
 https://hostingers.atlassian.net/browse/PLATFORM-1870



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to prevent duplicate releases of the same version. The CI/CD pipeline now verifies version tags before creating releases and ensures artifacts are only published when a new version is actually released, making the deployment process more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->