### PR TITLE
ci: alert Slack on release failure

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -89,3 +89,31 @@ jobs:
           npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify-failure:
+    needs: [release, publish-npmjs, publish-github]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on release failure
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          errors: true
+          webhook: ${{ secrets.PLATFORM_INCIDENT_SLACK_CHANNEL_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: ":rotating_light: Release failed in ${{ github.repository }}"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: |
+                    :rotating_light: *Release failed:* `${{ github.repository }}`
+                    *Commit:* <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>
+              - type: actions
+                elements:
+                  - type: button
+                    text:
+                      type: plain_text
+                      text: "View failed run"
+                    url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
Adds a `notify-failure` job to `build-release.yaml` that posts a Slack alert when the release pipeline fails.